### PR TITLE
Adding busstops search functionality endpoint

### DIFF
--- a/src/controllers/busStop.controllers.js
+++ b/src/controllers/busStop.controllers.js
@@ -1,4 +1,4 @@
-import Sequelize from 'sequelize';
+import Sequelize, { Op } from 'sequelize';
 import models from '../database/models';
 
 // prettier-ignore
@@ -162,6 +162,19 @@ const updateBusStop = (req, res) => {
     ));
 };
 
+const searchBusStop = (req, res) => {
+  let { bstop } = req.query;
+
+  bstop = bstop.toLowerCase();
+
+  models.busStops
+    .findAll({ where: { busStopName: { [Op.iLike]: `%${bstop}%` } } })
+    .then((busStops) => res.status(200).json({ busStops }))
+    .catch(() => {
+      res.status(404).json({ status: 404, message: 'No Result found' });
+    });
+};
+
 module.exports = {
   createBusStop,
   getAllBusStops,
@@ -169,4 +182,5 @@ module.exports = {
   getBusStopById,
   updateBusStop,
   deleteBusStop,
+  searchBusStop
 };

--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -256,7 +256,7 @@ const resetPassword = (req, res) => {
       }
       const updateUser = {
         email: decodedToken.email,
-        password: newPassword,
+        password: encryptPassword(newPassword),
         role: decodedToken.role,
         busId: decodedToken.busId,
       };

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,11 @@ import swaggerDocument from '../swagger.json';
 import routes from './routes/routes.route';
 import users from './routes/users.route';
 
+const app = express();
+
 const busRoutes = require('./routes/bus.route');
 
 const busstopRoutes = require('./routes/busStop.route');
-
-const app = express();
 
 app.use(express.json());
 app.use('/swaggerDocument', swaggerUi.serve, swaggerUi.setup(swaggerDocument));

--- a/src/routes/busStop.route.js
+++ b/src/routes/busStop.route.js
@@ -20,6 +20,8 @@ router.get('/allbusstop', controllers.getAllBusStopsGeoJson);
 
 router.get('/busstop/:id', [verifyAdminToken], controllers.getBusStopById);
 
+router.get('/searchbusstop', controllers.searchBusStop);
+
 router.patch('/busstop/:id', [verifyAdminToken, busStopUpdateInput],
   controllers.updateBusStop);
 

--- a/src/test/busStop.test.js
+++ b/src/test/busStop.test.js
@@ -178,3 +178,13 @@ describe('DELETE single busstop', () => {
     expect(res.statusCode).toEqual(500);
   });
 });
+
+describe('Search busstop by its name', () => {
+  it('Should search busstop and return all with Nya keyword', async (done) => {
+    const res = await request(app)
+      .get('/searchbusstop?bstop=Nya')
+      .set('Accept', 'application/json');
+    expect(res.statusCode).toEqual(200);
+    done();
+  });
+});


### PR DESCRIPTION
#### What does this PR do?

- Implementing Busstop search functionality

#### Description of Task to be completed?

- Creating an endpoint that enables users to search bus stop by its name
- Using query parameter to implement busstop search

#### How should this be manually tested?

- Clone `ft-busstop-search` branch
- Do `npm run dev`
- Open your postman and put this URL for search endpoint` http://localhost:9000/searchbusstop?bstop=<somethingToSearch>`
Where `<somethingToSearch>` is for Example `Rem` for Remera `Nyabu` for Nyabugogo, etc

#### Any background context you want to provide?

- User can be able to search busstop by its name

#### What are the relevant Trello boards stories?

- https://trello.com/c/EtYYiiO2/127-create-an-endpoint-to-search-bus-stops-by-name

#### Screenshots (if appropriate)

- N/A

#### Questions:

- N/Q